### PR TITLE
Align version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="kubestriker",
-    version="v1.0.0",
+    version="1.1.0",
     author="vasant chinnipilli",
     author_email="vchinnipilli@gmail.com.com",
     description="A Blazing fast Security Auditing tool for Kuberentes",


### PR DESCRIPTION
The latest and tagged release is [1.1.0](https://github.com/vchinnipilli/kubestriker/releases/tag/v1.1.0).

The mismatch requires additional patching for distributions.