### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     author="vasant chinnipilli",
     author_email="vchinnipilli@gmail.com.com",
     description="A Blazing fast Security Auditing tool for Kuberentes",
-    licnese="Apache-2.0",
+    license="Apache-2.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vchinnipilli/kubestriker",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setuptools.setup(
     author="vasant chinnipilli",
     author_email="vchinnipilli@gmail.com.com",
     description="A Blazing fast Security Auditing tool for Kuberentes",
+    licnese="Apache-2.0",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vchinnipilli/kubestriker",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.